### PR TITLE
Support case when swap is disabled + renaming namespaces 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,20 @@ This plugin has the ability to gather the following metrics:
 
 Namespace | Data Type | 
 ----------|-----------|
-/intel/linux/swap/io/in_bytes_per_sec | float64 | 
-/intel/linux/swap/io/in_pages_per_sec | float64 | 
-/intel/linux/swap/io/out_bytes_per_sec | float64 | 
-/intel/linux/swap/io/out_pages_per_sec | float64 | 
-/intel/linux/swap/device/{device}/used_bytes | float64 | 
-/intel/linux/swap/device/{device}/used_percent | float64 | 
-/intel/linux/swap/device/{device}/free_bytes | float64 | 
-/intel/linux/swap/device/{device}/free_percent | float64 | 
-/intel/linux/swap/all/used_bytes | float64 | 
-/intel/linux/swap/all/used_percent | float64 | 
-/intel/linux/swap/all/free_bytes | float64 | 
-/intel/linux/swap/all/free_percent | float64 | 
-/intel/linux/swap/all/cached_bytes | float64 | 
-/intel/linux/swap/all/cached_percent | float64 | 
+/intel/procfs/swap/io/in_bytes_per_sec | float64 | 
+/intel/procfs/swap/io/in_pages_per_sec | float64 | 
+/intel/procfs/swap/io/out_bytes_per_sec | float64 | 
+/intel/procfs/swap/io/out_pages_per_sec | float64 | 
+/intel/procfs/swap/device/{device}/used_bytes | float64 | 
+/intel/procfs/swap/device/{device}/used_percent | float64 | 
+/intel/procfs/swap/device/{device}/free_bytes | float64 | 
+/intel/procfs/swap/device/{device}/free_percent | float64 | 
+/intel/procfs/swap/all/used_bytes | float64 | 
+/intel/procfs/swap/all/used_percent | float64 | 
+/intel/procfs/swap/all/free_bytes | float64 | 
+/intel/procfs/swap/all/free_percent | float64 | 
+/intel/procfs/swap/all/cached_bytes | float64 | 
+/intel/procfs/swap/all/cached_percent | float64 | 
 
 ### Examples
 Example task manifest to use swap plugin:
@@ -72,20 +72,20 @@ Example task manifest to use swap plugin:
     "workflow": {
         "collect": {
             "metrics": {
-                "/intel/linux/swap/device/dev_sda5/used_bytes": {},
-                "/intel/linux/swap/device/dev_sda5/used_percent": {},
-                "/intel/linux/swap/device/dev_sda5/free_bytes": {},
-                "/intel/linux/swap/device/dev_sda5/free_percent": {},
-                "/intel/linux/swap/all/cached_bytes": {},
-                "/intel/linux/swap/all/cached_percent":{},
-                "/intel/linux/swap/all/free_bytes":{},
-                "/intel/linux/swap/all/free_percent":{},
-                "/intel/linux/swap/all/used_bytes":{},
-                "/intel/linux/swap/all/used_percent":{},
-                "/intel/linux/swap/io/in_bytes_per_sec":{},
-                "/intel/linux/swap/io/in_pages_per_sec":{},
-                "/intel/linux/swap/io/out_bytes_per_sec":{},
-                "/intel/linux/swap/io/out_pages_per_sec":{}
+                "/intel/procfs/swap/device/dev_sda5/used_bytes": {},
+                "/intel/procfs/swap/device/dev_sda5/used_percent": {},
+                "/intel/procfs/swap/device/dev_sda5/free_bytes": {},
+                "/intel/procfs/swap/device/dev_sda5/free_percent": {},
+                "/intel/procfs/swap/all/cached_bytes": {},
+                "/intel/procfs/swap/all/cached_percent":{},
+                "/intel/procfs/swap/all/free_bytes":{},
+                "/intel/procfs/swap/all/free_percent":{},
+                "/intel/procfs/swap/all/used_bytes":{},
+                "/intel/procfs/swap/all/used_percent":{},
+                "/intel/procfs/swap/io/in_bytes_per_sec":{},
+                "/intel/procfs/swap/io/in_pages_per_sec":{},
+                "/intel/procfs/swap/io/out_bytes_per_sec":{},
+                "/intel/procfs/swap/io/out_pages_per_sec":{}
             },
             "config": {
             },

--- a/examples/tasks/swap-file.json
+++ b/examples/tasks/swap-file.json
@@ -7,23 +7,22 @@
     "workflow": {
         "collect": {
             "metrics": {
-                "/intel/linux/swap/device/dev_sda5/used_bytes": {},
-                "/intel/linux/swap/device/dev_sda5/used_percent": {},
-                "/intel/linux/swap/device/dev_sda5/free_bytes": {},
-                "/intel/linux/swap/device/dev_sda5/free_percent": {},
-		"/intel/linux/swap/all/cached_bytes": {},
-		"/intel/linux/swap/all/cached_percent":{},
-		"/intel/linux/swap/all/free_bytes":{},
-		"/intel/linux/swap/all/free_percent":{},
-		"/intel/linux/swap/all/used_bytes":{},
-		"/intel/linux/swap/all/used_percent":{},          
-		"/intel/linux/swap/io/in_bytes_per_sec":{},
-		"/intel/linux/swap/io/in_pages_per_sec":{},
-		"/intel/linux/swap/io/out_bytes_per_sec":{},
-		"/intel/linux/swap/io/out_pages_per_sec":{}
+                "/intel/procfs/swap/device/dev_sda5/used_bytes": {},
+                "/intel/procfs/swap/device/dev_sda5/used_percent": {},
+                "/intel/procfs/swap/device/dev_sda5/free_bytes": {},
+                "/intel/procfs/swap/device/dev_sda5/free_percent": {},
+                "/intel/procfs/swap/all/cached_bytes": {},
+                "/intel/procfs/swap/all/cached_percent": {},
+                "/intel/procfs/swap/all/free_bytes": {},
+                "/intel/procfs/swap/all/free_percent": {},
+                "/intel/procfs/swap/all/used_bytes": {},
+                "/intel/procfs/swap/all/used_percent": {},
+                "/intel/procfs/swap/io/in_bytes_per_sec": {},
+                "/intel/procfs/swap/io/in_pages_per_sec": {},
+                "/intel/procfs/swap/io/out_bytes_per_sec": {},
+                "/intel/procfs/swap/io/out_pages_per_sec": {}
             },
-            "config": {
-            },
+            "config": {},
             "process": null,
             "publish": [
                 {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -4,7 +4,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,58 +32,58 @@ import (
 var (
 	mockMts = []plugin.PluginMetricType{
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "io", "in_bytes_per_sec"},
+			Namespace_: []string{"intel", "procfs", "swap", "io", "in_bytes_per_sec"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "io", "in_pages_per_sec"},
+			Namespace_: []string{"intel", "procfs", "swap", "io", "in_pages_per_sec"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "io", "out_bytes_per_sec"},
+			Namespace_: []string{"intel", "procfs", "swap", "io", "out_bytes_per_sec"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "io", "out_pages_per_sec"},
+			Namespace_: []string{"intel", "procfs", "swap", "io", "out_pages_per_sec"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "device", "dev_sda5", "used_bytes"},
+			Namespace_: []string{"intel", "procfs", "swap", "device", "dev_sda5", "used_bytes"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "device", "dev_sda6", "used_bytes"},
+			Namespace_: []string{"intel", "procfs", "swap", "device", "dev_sda6", "used_bytes"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "device", "dev_sda5", "used_percent"},
+			Namespace_: []string{"intel", "procfs", "swap", "device", "dev_sda5", "used_percent"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "device", "dev_sda6", "used_percent"},
+			Namespace_: []string{"intel", "procfs", "swap", "device", "dev_sda6", "used_percent"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "device", "dev_sda5", "free_bytes"},
+			Namespace_: []string{"intel", "procfs", "swap", "device", "dev_sda5", "free_bytes"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "device", "dev_sda6", "free_bytes"},
+			Namespace_: []string{"intel", "procfs", "swap", "device", "dev_sda6", "free_bytes"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "device", "dev_sda5", "free_percent"},
+			Namespace_: []string{"intel", "procfs", "swap", "device", "dev_sda5", "free_percent"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "device", "dev_sda6", "free_percent"},
+			Namespace_: []string{"intel", "procfs", "swap", "device", "dev_sda6", "free_percent"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "all", "used_bytes"},
+			Namespace_: []string{"intel", "procfs", "swap", "all", "used_bytes"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "all", "used_percent"},
+			Namespace_: []string{"intel", "procfs", "swap", "all", "used_percent"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "all", "free_bytes"},
+			Namespace_: []string{"intel", "procfs", "swap", "all", "free_bytes"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "all", "free_percent"},
+			Namespace_: []string{"intel", "procfs", "swap", "all", "free_percent"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "all", "cached_bytes"},
+			Namespace_: []string{"intel", "procfs", "swap", "all", "cached_bytes"},
 		},
 		plugin.PluginMetricType{
-			Namespace_: []string{"intel", "linux", "swap", "all", "cached_percent"},
+			Namespace_: []string{"intel", "procfs", "swap", "all", "cached_percent"},
 		},
 	}
 	ioNewMockFile  = "/tmp/vmstat_test"


### PR DESCRIPTION
- avoid dividing by zero (that caused errors in case when swap is turned off)
- renaming namespaces, "procfs" instead "linux"
